### PR TITLE
Fixed installation error 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     aws.s3,
     pander
 Remotes:
-    yihui/printr
+    yihui/printr,
     timriffe/TR1/TR1/HMDHFDplus
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1


### PR DESCRIPTION
Fixed error for installing due to missing comma using devtools and remotes install_github command.
The error was 
Downloading GitHub repo lehmansociology/lehmansociology@master
Error: Failed to install 'lehmansociology' from GitHub:
  Missing commas separating Remotes: 'yihui/printr
    timriffe/TR1/TR1/HMDHFDplus'
Added comma to fix the error now its working.